### PR TITLE
Fix a few things in the linux installation doc

### DIFF
--- a/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/installing-on-linux.md
+++ b/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/installing-on-linux.md
@@ -6,20 +6,20 @@ AppFlowy currently does not have a formal Linux installation process. However, t
 
 **Note:**
 
-* The following steps are verified on
+* The following steps have been verified on the following Linux distributions:
   * [x] lubuntu 20.04 - X86\_64
-  * [ ] ubuntu 20.04 - aarch64
-  * [ ] redhat - X86\_64
   * [x] Arch Linux - X86\_64
-  * [ ] Deepin - X86\_64
-  * [ ] Raspberry Pi OS - aarch64
+  * [x] Ubuntu 20.04 - x86\_64
+  
+  Any Linux distribution not listed here has not been tested, and the following steps may not work. If you are trying to install AppFlowy on a Linux distribution not listed here, let us know how it went so that we can add it to the list or fix any bugs that may ocurr.
 
 ### Steps to install AppFlowy on Linux\*\*
 
 1. Download the latest archive file from the [Releases](https://github.com/AppFlowy-IO/appflowy/releases) page.
 2.  Extract the archive in a location of your choice (i.e. /opt/)
 
-    **note :** The application will be extracted into a folder named AppFlowy
+    **note:** Performing read/write operations in folders such as `/opt` may require root access. If a command fails due to missing permissions, try running it as the root user (this may be done by switching to the root user or using programs such as sudo and doas)
+    **note:** The application will be extracted into a folder named AppFlowy
 
 ```shell
 tar -xzvf AppFlowy-linux-x86.tar.gz
@@ -43,7 +43,7 @@ cd AppFlowy
 The current documentation may be out of sync with the development.&#x20;
 
 * If your icon file is named `flowylogo.svg` **** please rename it to `app_flowy.svg`
-* Your appflowy.desktop file should have the line `Icon=app_flowy`
+* Your appflowy.desktop file should have the line `Icon=<installation_dir>/AppFlowy/app_flowy.svg`
 {% endhint %}
 
 Adding an application to Linux's system menu requires some extra steps. In the steps below we assume that you have extracted the archive file into the `/opt/` directory and that your present working directory is `/opt/AppFlowy`.


### PR DESCRIPTION
Was testing out the install instructions for Linux and noticed a few things that could be fixed:

- Tested distribution list
- Note about missing permissions
- Fix icon path note