### PR TITLE
[docs] Change aarch64 to match arm64 in Makefile.toml

### DIFF
--- a/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-macos.md
+++ b/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-macos.md
@@ -69,9 +69,9 @@ cargo make --profile production-mac-x86 appflowy
 ```
 {% endtab %}
 
-{% tab title="aarch64" %}
+{% tab title="arm64" %}
 ```shell
-cargo make --profile production-mac-aarch64 appflowy
+cargo make --profile production-mac-arm64 appflowy
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
`Makefile.toml` specifies the environment variables for `production-mac-arm64` but documentation uses `production-mac-aarch64`. We must either modify the documentation or change the config file.