### PR TITLE
Update documentation for macOs

### DIFF
--- a/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-macos.md
+++ b/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-macos.md
@@ -21,6 +21,7 @@ Skip this if flutter is already installed on your system.
 {% endhint %}
 
 * Follow the instructions [here](https://flutter.dev/docs/get-started/install) to install Flutter.
+* Make sure you also install the [Flutter](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter) & [Dart](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code) extensions in VS Code.
 
 ## **Step 3: Install your build environment**
 
@@ -30,16 +31,22 @@ Skip this if flutter is already installed on your system.
 ./frontend/scripts/install_dev_env/install_macos.sh
 ```
 
-> FYI, AppFlowy uses [https://github.com/sagiegurari/cargo-make](https://github.com/sagiegurari/cargo-make) to construct the build scripts
+> FYI, AppFlowy uses [https://github.com/sagiegurari/cargo-make](https://github.com/sagiegurari/cargo-make) to construct the build scripts.
+> It is important that you add (dart) `pub` to $PATH, otherwise VS Code may error out. Add the following to your `.bashrc` or `.zshrc` in `$HOME`:
+> ```
+> export PATH="$PATH":"$HOME/.pub-cache/bin"
+> ```
+> Make sure to restart your terminal and VS Code
 
 ## **Step 4: Edit and run the application**
 
-1. Open the `frontend` folder located at xx/AppFlowy/frontend with VS Code.
-2. Go to the Run and Debug tab and then click AF: Clean + Rebuild All for the first time running.
+1. Open the `frontend` folder located at xx/AppFlowy/frontend with VS Code. It is important *not* to open the root folder, as that will not give access to the appropriate debug commands.
+2. Check the device selection, as of now AppFlowy only supports Desktop: 
+![device](https://user-images.githubusercontent.com/86001920/144546864-cebbf0c0-4eef-424e-93c7-e1e6b3a59669.png)
+3. Go to the Run and Debug tab and then click AF: Clean + Rebuild All for the first time running.
 
 ![img.png](../../../../.gitbook/assets/launch\_appflowy.png)
 
-* Please also check the device selection, as of now AppFlowy only supports Desktop: ![device](https://user-images.githubusercontent.com/86001920/144546864-cebbf0c0-4eef-424e-93c7-e1e6b3a59669.png)
 
 If you encounter any issues, have a look at [Troubleshooting](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/trouble-shotting) first. If your issue is not included in the page, please create an [issue](https://github.com/AppFlowy-IO/appflowy/issues/new/choose) or ask on [Discord](https://discord.gg/9Q2xaN37tV).
 


### PR DESCRIPTION
- Recommend installing VS Code extensions (as debug script won't work without it)
- Move around documentation in Step 4, as currently it isn't an optional note but a requirement
- Add clarity to bullet 1, in Step 4.
- Added additional information in Step 3 info box

These are minor but I lacked that information when starting, so figured someone else might too.