### PR TITLE
Fix Troubleshooting typo

### DIFF
--- a/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/troubleshooting.md
+++ b/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/troubleshooting.md
@@ -3,5 +3,5 @@
 ## Protobuf Generation Errors
 ### 1.The protoc-gen-dart plugin error
 
-Because VS Code uses bash as the default terminal, ensure the $HOME/.pub-cache/bin is not shown in your $PATH.
+Because VS Code uses bash as the default terminal, ensure the $HOME/.pub-cache/bin is shown in your $PATH.
 You can check out this [link](https://github.com/AppFlowy-IO/AppFlowy/issues/413) for more information.

--- a/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/installing-on-linux/installing-and-setting-up-flutter-on-linux-from-source.md
+++ b/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/installing-on-linux/installing-and-setting-up-flutter-on-linux-from-source.md
@@ -61,3 +61,11 @@ Check if the Flutter PATH is added into your shell.
 ```shell
 echo $PATH
 ```
+Once you've confirmed that flutter is installed and added to PATh, run 
+```shell
+flutter --version
+```
+
+You should see a screen that welcomes you and the version.
+
+![flutter](https://user-images.githubusercontent.com/109571434/191872386-6694e72d-5bdb-4de4-ad59-86830f830f33.png)


### PR DESCRIPTION
As the [build steps](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-macos#step-3-install-your-build-environment) says, dart pub should be added to `$PATH`, otherwise VS Code may error out.

