### PR TITLE
Fix Troubleshooting typo

### DIFF
--- a/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/troubleshooting.md
+++ b/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/troubleshooting.md
@@ -3,5 +3,5 @@
 ## Protobuf Generation Errors
 ### 1.The protoc-gen-dart plugin error
 
-Because VS Code uses bash as the default terminal, ensure the $HOME/.pub-cache/bin is not shown in your $PATH.
+Because VS Code uses bash as the default terminal, ensure the $HOME/.pub-cache/bin is shown in your $PATH.
 You can check out this [link](https://github.com/AppFlowy-IO/AppFlowy/issues/413) for more information.


### PR DESCRIPTION
As the [build steps](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-macos#step-3-install-your-build-environment) says, dart pub should be added to $PATH, otherwise VS Code may error out.