### PR TITLE
Arch linux: use pacman instead of yay

### DIFF
--- a/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-linux.md
+++ b/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-linux.md
@@ -56,7 +56,7 @@ sudo apt-get install curl build-essential libsqlite3-dev libssl-dev clang cmake 
 
 {% tab title="Arch" %}
 ```bash
-yay -S curl base-devel sqlite openssl clang cmake ninja pkg-config gtk3 unzip
+sudo pacman -S curl base-devel sqlite openssl clang cmake ninja pkg-config gtk3 unzip
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
There are other alternatives to yay, we shouldn't be dependant on a 3rd party package manager