### PR TITLE
Add cask to homebrew command

### DIFF
--- a/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/README.md
+++ b/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/README.md
@@ -3,7 +3,7 @@
 ## Mac Install
 
 ```
-brew install appflowy
+brew install --cask appflowy
 ```
 
 ## Packages


### PR DESCRIPTION
When using homebrew and a GUI application you want to use `--cask` since it wont show up as an Application otherwise