### PR TITLE
docs: add instructions to install from flathub

### DIFF
--- a/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/README.md
+++ b/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/README.md
@@ -1,5 +1,13 @@
 # Mac / Windows / Linux Packages
 
+## Linux Install
+
+AppFlowy is available on [Flathub](https://flathub.org/apps/details/io.appflowy.AppFlowy).
+
+```
+flatpak install flathub io.appflowy.AppFlowy
+```
+
 ## Mac Install
 
 ```


### PR DESCRIPTION
None of the current instructions actually mention that the app is available as a flatpak.