### PR TITLE
chore: add protoc plugin to windows installation

### DIFF
--- a/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-windows.md
+++ b/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-windows.md
@@ -95,6 +95,12 @@ perl --version
 
 * Install Dart extension for Visual Studio Code
 
+* Enable the Dart `protoc_plugin`
+
+```shell
+dart pub global activate protoc_plugin
+```
+
 * For Windows 11: Activate Developer Mode
   * Go to Settings > Privacy & Security > switch ON Developer Mode
 


### PR DESCRIPTION
I wasn't able to build on windows without this, Riley let me know I was missing it.

Whilst doing this PR, I found that there is a step in troubleshooting that checks if it's installed, but I'm pretty sure we should have it in the setup guide.

Should we add this to Linux and MacOS steps as well?