### PR TITLE
Fix create a plugin how-to page's link

### DIFF
--- a/essential-documentation/contribute-to-appflowy/software-contributions/how-tos/how-to-create-a-plugin-for-appflowy-editor.md
+++ b/essential-documentation/contribute-to-appflowy/software-contributions/how-tos/how-to-create-a-plugin-for-appflowy-editor.md
@@ -4,4 +4,4 @@ description: https://pub.dev/packages/appflowy_editor
 
 # 🧩 How to Create a Plugin for AppFlowy Editor
 
-[https://github.com/AppFlowy-IO/AppFlowy/blob/main/frontend/app\_flowy/packages/appflowy\_editor/documentation/customizing.md](https://github.com/AppFlowy-IO/AppFlowy/blob/main/frontend/app\_flowy/packages/appflowy\_editor/documentation/customizing.md)
+[https://github.com/AppFlowy-IO/appflowy-editor/blob/main/documentation/customizing.md](https://github.com/AppFlowy-IO/AppFlowy/blob/main/frontend/app\_flowy/packages/appflowy\_editor/documentation/customizing.md)


### PR DESCRIPTION
Fix the link on the "create a plugin" how-to page.
https://github.com/AppFlowy-IO/AppFlowy/issues/2505