### PR TITLE
The spelling of windows was incorrect,I just corrected it

### DIFF
--- a/essential-documentation/contribute-to-appflowy/write-for-appflowy/how-appflowy-uses-flutter-bloc.md
+++ b/essential-documentation/contribute-to-appflowy/write-for-appflowy/how-appflowy-uses-flutter-bloc.md
@@ -1,0 +1,54 @@
+# Simplify State Management in AppFlowy with Flutter Bloc
+
+State management is a critical aspect of building mobile applications, and in AppFlowy, we've found an excellent solution with Flutter Bloc. Flutter Bloc is a powerful state management library that helps us handle state in a predictable and maintainable way. In this article, we'll explore how AppFlowy leverages Flutter Bloc to streamline state management and deliver an exceptional user experience.
+
+## The Power of Flutter Bloc
+
+Flutter Bloc follows the Business Logic Component (BLoC) architectural pattern and promotes a clear separation of concerns between the business logic and the user interface. This architectural approach brings several benefits to AppFlowy:
+
+### 1. Organized Codebase
+
+AppFlowy's codebase is neatly organized into distinct blocs, each responsible for managing a specific part of the application state. For example, we have a TaskBloc, CategoryBloc, and UserBloc, each handling their respective state and events. This organization ensures that our code remains modular and maintainable, allowing us to easily navigate and enhance different parts of the application.
+
+### 2. Event-Driven State Changes
+
+In Flutter Bloc, events trigger state changes. When an event occurs, such as adding a new task or updating a user profile, the corresponding bloc processes the event and updates the state accordingly. For instance, the TaskBloc would handle an AddTaskEvent and update the task list state. By adopting this event-driven approach, AppFlowy maintains a predictable flow of state changes, making debugging and testing easier.
+
+### 3. Responsive User Interface
+
+AppFlowy's user interface seamlessly integrates with Flutter Bloc. Widgets and UI components subscribe to the relevant blocs to receive updates on the application state. As the state changes, these components reactively update to reflect the latest information. For example, when a user completes a task, the TaskListWidget instantly refreshes to show the updated task list. This responsiveness enhances the user experience and ensures a smooth and interactive interface.
+
+### 4. Scalability and Reusability
+
+With Flutter Bloc, AppFlowy is ready to scale and accommodate future growth. As new features are introduced, we can easily create additional blocs to manage the related state without impacting the existing codebase. The modular nature of Flutter Bloc also promotes code reuse. Existing blocs can be reused across different parts of the application, reducing duplication and increasing development efficiency.
+
+## An Illustration of Flutter Bloc in AppFlowy
+
+![AppFlowy Architecture image illustration](https://images.squarespace-cdn.com/content/v1/617f6f16b877c06711e87373/ee5c2cd0-b697-48ec-9c98-6a3871740d06/components.png?format=1500w)
+### For applflowy architecture you can visit here:-
+- [Appflowy Architecture](https://appflowy.io/blog/how-we-built-appflowy-with-flutter-and-rust)
+To provide a concrete example, let's consider the scenario of creating a new task in AppFlowy:
+
+1. The user interacts with the UI by adding a new task through the TaskCreationWidget.
+2. The TaskCreationWidget dispatches an AddTaskEvent to the TaskBloc.
+3. The TaskBloc receives the event and processes it within the mapEventToState method.
+4. The TaskBloc updates the state to reflect the addition of the new task, for example, by emitting a TaskAddedState.
+5. The TaskListWidget, which is subscribed to the TaskBloc, receives the updated state and automatically refreshes to display the new task.
+
+This seamless flow of events and state changes ensures that AppFlowy remains synchronized and responsive to user interactions.
+
+## Conclusion
+
+In summary, AppFlowy relies on the power of Flutter Bloc for efficient state management. By organizing the codebase into blocs, handling event-driven state changes, and integrating with the user interface, AppFlowy delivers a streamlined user experience. The clear separation of concerns, responsiveness of the user interface, and scalability provided by Flutter Bloc make it a valuable tool for managing complex state in mobile applications.
+
+Give Flutter Bloc a try in your own projects, and experience the benefits it brings to state management. Here are some final thoughts to consider:
+
+- **Easy Testing**: Flutter Bloc's architecture lends itself well to testing. Since the business logic is separated from the UI, it becomes straightforward to write unit tests for individual blocs, ensuring that they behave as expected under different scenarios. This helps catch bugs early and maintain the overall stability of the application.
+
+- **Community Support**: Flutter Bloc has a thriving community with a wealth of resources, tutorials, and examples available. If you ever run into any challenges or need guidance, you can rely on the community to provide assistance and share best practices. This vibrant ecosystem ensures that you're not alone in your journey with Flutter Bloc.
+
+- **Expanding Functionality**: As AppFlowy evolves and new features are introduced, Flutter Bloc remains a reliable solution. Whether you need to introduce complex state management for user authentication, implement real-time updates through websockets, or integrate with third-party APIs, Flutter Bloc's flexibility and modularity make it adaptable to a wide range of requirements.
+
+In conclusion, Flutter Bloc has proven to be a valuable asset in AppFlowy's state management strategy. The clear separation of concerns, event-driven approach, and seamless integration with the user interface contribute to a well-structured and maintainable codebase. By leveraging the power of Flutter Bloc, AppFlowy delivers a smooth, responsive, and scalable user experience.
+
+Give it a try in your own Flutter projects, explore the possibilities, and unlock the potential of Flutter Bloc in your state management endeavors. Happy coding!

--- a/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/README.md
+++ b/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages/README.md
@@ -30,6 +30,6 @@ brew install --cask appflowy
 
 ##
 
-## Windowns install
+## Windows install
 
 You can download the executable directly from [Github](https://github.com/AppFlowy-IO/appflowy/releases)


### PR DESCRIPTION
I have fixed a typo error which was on the https://appflowy.gitbook.io/docs/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages
...Please merge it

![image](https://github.com/AppFlowy-IO/AppFlowy-Docs/assets/118105825/9a780fa7-840a-4af9-a297-a29e316f9da2)
"Windows Spelling is incorrect"
