### PR TITLE
Update rust version in environment setup docs (1.65 -> 1.70+)

### DIFF
--- a/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/README.md
+++ b/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/README.md
@@ -15,7 +15,7 @@ dart pub global activate protoc_plugin 20.0.1
 {% endhint %}
 
 {% hint style="warning" %}
-Rust version 1.65 is the version that AppFlowy is built and tested on. If you installed Rust before, make sure the version matches AppFlowy's.
+Rust version updates regularly (currently 1.70+). If you have installed Rust before, make sure the stable version matches AppFlowy's (see `RUST_TOOLCHAIN` in `.github/workflows`).
 {% endhint %}
 
 [Building on Linux](building-on-linux.md)


### PR DESCRIPTION
Current rust version 1.65 listed is out of date and local rust compilation fails for <1.68 versions already.

This wording should future-proof the setup docs to account for new rust version changes in the main repo.