### PR TITLE
docs: fixed typo appflowy_flutter

### DIFF
--- a/essential-documentation/contribute-to-appflowy/architecture/frontend/frontend/codemap.md
+++ b/essential-documentation/contribute-to-appflowy/architecture/frontend/frontend/codemap.md
@@ -2,7 +2,7 @@
 
 This code map introduces the folder hierarchy of AppFlowy.
 
-1. **`app_flowy`** : The flutter working directory, includes all the Dart code of AppFlowy.
+1. **`appflowy_flutter`** : The flutter working directory, includes all the Dart code of AppFlowy.
    1.  **`assets`**:
 
        The directory contains all the resources that AppFlowy uses.


### PR DESCRIPTION
Fixed the typo of Working directory of Flutter from `app_flowy` to `appflowy_flutter`
Closes issue #138 