### PR TITLE
Fix environnement broken link on draft-how-to-contribute-to-appflowy

### DIFF
--- a/documentation/appflowy/draft-how-to-contribute-to-appflowy.md
+++ b/documentation/appflowy/draft-how-to-contribute-to-appflowy.md
@@ -133,7 +133,7 @@ As mentioned previously, we expect you to make contributions using the [GitHub W
 That means following these standard steps:
 
 1. Create your own branch within your forked repository
-2. Set up your development [environment](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions#environment-setup)
+2. Set up your development [environment](https://docs.appflowy.io/docs/documentation/appflowy/from-source/environment-setup)
 3. Make changes to the codebase in accordance with the requirements and tasks present in the _Issue_ that you have chosen to work on
 4. Add unit tests for any new features as necessary
 5. Push the changes to your branch and create a Pull Request for the same


### PR DESCRIPTION
Broken link on : https://docs.appflowy.io/docs/documentation/appflowy/draft-how-to-contribute-to-appflowy#working-on-your-issue

I fix it by replacing the current link with the current one :https://docs.appflowy.io/docs/documentation/appflowy/from-source/environment-setup 

NOTE: This is my first PR on this project, i would like to contribute more so I tried something simple before going further with you, tell me if something is not good