### PR TITLE
Fix link to installation page

### DIFF
--- a/appflowy/install-appflowy/README.md
+++ b/appflowy/install-appflowy/README.md
@@ -4,7 +4,7 @@
 These are instructions for an end user.
 {% endhint %}
 
-These are the installation instructions for an end user.  If you wish to contribute to AppFlowy or if you just want to view and run directly from source code please visit the [Broken link](broken-reference "mention") section.
+These are the installation instructions for an end user.  If you wish to contribute to AppFlowy or if you just want to view and run directly from source code please visit the [Install AppFlowy](../readme/install-appflowy.md "mention") section.
 
 You can view the [requirements.md](requirements.md "mention")
 

--- a/appflowy/install-appflowy/README.md
+++ b/appflowy/install-appflowy/README.md
@@ -4,7 +4,7 @@
 These are instructions for an end user.
 {% endhint %}
 
-These are the installation instructions for an end user.  If you wish to contribute to AppFlowy or if you just want to view and run directly from source code please visit the [Install AppFlowy](../readme/install-appflowy.md "mention") section.
+These are the installation instructions for an end user.  If you wish to contribute to AppFlowy or if you just want to view and run directly from source code please visit the [Building from Source](../../documentation/appflowy/from-source "mention") section.
 
 You can view the [requirements.md](requirements.md "mention")
 


### PR DESCRIPTION
Fix broken link:

https://docs.appflowy.io/docs/appflowy/install-appflowy

![appflowy install](https://github.com/AppFlowy-IO/AppFlowy-Docs/assets/16005946/f442de08-0fa9-4aaa-a962-f608f3503c0f)
