### PR TITLE
Update discord link

### DIFF
--- a/appflowy/community/get-in-contact.md
+++ b/appflowy/community/get-in-contact.md
@@ -6,7 +6,7 @@ We're thrilled to have you here and can't wait to connect with you. Whether you 
 
 Looking to report a bug, request a feature, or discuss a project in-depth? GitHub is the place to be! Head over to our repository and dive into the issues or discussions. We're always eager to hear your thoughts and collaborate on exciting projects.
 
-[**2. Discord**](https://discord.gg/Hjp2qhS2ZJ)
+[**2. Discord**](https://discord.gg/9Q2xaN37tV)
 
 Fancy some real-time chatting with fellow enthusiasts and our friendly team members? Join our Discord server! It's a vibrant hub for community discussions, troubleshooting, and connecting with like-minded folks.
 


### PR DESCRIPTION
Hello,
I noticed that the Discord link in the documentation was invalid when I tried to use it. To find an active link, I searched the subreddit and found a working invitation that seems to be set to never expire. I assume this as it's more than 7 days old and when I clicked make a new invite link on Discord it said the link is set to expire in 7 days or I can click a button to set it to never expire). I've updated the link in the documentation accordingly. 

Also this is my first pull request please let me know if I did anything wrong or any best practices I am missing.

Thanks for your work on this project,
Mo