### PR TITLE
Improve wording and correct markdown

### DIFF
--- a/documentation/appflowy-cloud/architecture.md
+++ b/documentation/appflowy-cloud/architecture.md
@@ -1,11 +1,11 @@
 # 🌈 Architecture
 
-* This articles goes through self-host AppFlowy Cloud's architecture after deployment.
+* This article goes through self-hosting AppFlowy Cloud's architecture after deployment.
 * For the rest of the article, we will `myhost` as the hostname/ip of the machine where AppFlowy Cloud is deployed in.
 
 ![img\_1.png](img\_1.png)
 
-From the diagram, there are 5 entrypoints for end user usage, we categorized them into the following
+From the diagram, there are 5 entry points for end user usage, we categorized them into the following
 
 * Client Usage
 * Observability Tools
@@ -33,7 +33,7 @@ This is where regular AppFlowy Cloud users should spend most of their time in.
 
 ## Observability Tools
 
-Strictly speaking, the following are not essentially for cloud functionality, but recommended to have for various reasons including:
+Strictly speaking, the following are not essential for cloud functionality, but recommended to have for various reasons including:
 
 * Resource Usage
 * Database performance
@@ -48,13 +48,13 @@ Usernames and password are generated during the initialization phase. Kindly ref
 
 ### Minio Web UI
 
-* Depdency: None
+* Dependency: None
 * File storage management
 * Accessible at [https://myhost/minio](https://myhost/web)
 
 ### Portainer
 
-* Depdency: None
+* Dependency: None
 * Docker container management
 * Accessible at https://myhost/portainer
 

--- a/documentation/appflowy-editor/licenses.md
+++ b/documentation/appflowy-editor/licenses.md
@@ -13,7 +13,7 @@
 
 **Q3:** How does the scope of the MPL’s copyleft compare with the LGPL and GPL’s copyleft?
 
-[**A**](https://www.mozilla.org/en-US/MPL/2.0/FAQ/#copyleft-scope)**:** MPL is less restrictive than LGPL and GPL. MPL’s copyleft applies to any files containing MPLed code. LGPL’s copyleft applies to any library based on LGPLed code. GPL’s copyleft applies to all software based on GPLed code. To better understand how the LGPL and GPL define “based on,” please read the licences and consult with your legal. [Here](https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/) is an article that explains the differences between these weak copyleft licenses.
+[**A**](https://www.mozilla.org/en-US/MPL/2.0/FAQ/#copyleft-scope)**:** MPL is less restrictive than LGPL and GPL. MPL’s copyleft applies to any files containing MPLed code. LGPL’s copyleft applies to any library based on LGPLed code. GPL’s copyleft applies to all software based on GPLed code. To better understand how the LGPL and GPL define “based on,” please read the licenses and consult with your legal team. [Here](https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/) is an article that explains the differences between these weak copyleft licenses.
 
 
 

--- a/essential-documentation/appflowy-x-openai.md
+++ b/essential-documentation/appflowy-x-openai.md
@@ -23,7 +23,7 @@
 
 * **AI Writer**: Ask AI to write anything for you. Let AI draft it for you whenever you're starting something new.
 * **Summarize**: Auto-generate a nice summary for an article, your proposal, or anything else.
-* **Fix spelling & grammar**: With one click away, catch and fix spelling and grammatical errors, enhance the readability and clarity of your text, and provide context-aware suggestions.
+* **Fix spelling & grammar**: With one click, catch and fix spelling and grammatical errors, enhance the readability and clarity of your text, and provide context-aware suggestions.
 * **Improve Writing**: There is no need to switch between different tools; simply highlight the text and ask AI to quickly transform it into something better and more suitable for the task.
 * **Make longer:** AI will automatically rewrite its response with more copy.
 
@@ -57,7 +57,7 @@ Go to Settings -> AI Settings
 * Go to Settings -> Plan&#x20;
 * Purchase AI On-device add-on\
   ![](<../.gitbook/assets/image (81).png>)
-* Follow [appflowy-ai-on-device.md](../appflowy/product/appflowy-ai-on-device.md "mention")to enable it.
+* Follow [appflowy-ai-on-device.md](../appflowy/product/appflowy-ai-on-device.md "mention") to enable it.
 
 
 

--- a/essential-documentation/databases/manage-properties.md
+++ b/essential-documentation/databases/manage-properties.md
@@ -1,5 +1,5 @@
 ---
-description: Working in progress
+description: Work in progress...
 ---
 
 # 🗃️ Manage Properties

--- a/essential-documentation/duplicate-delete-and-restore.md
+++ b/essential-documentation/duplicate-delete-and-restore.md
@@ -6,4 +6,4 @@ Hover on a block to trigger the action menu where you can find `Duplicate` and `
 
 Choosing Delete will delete the selected block.&#x20;
 
-Choosing Duplicate with make a copy of the selected block and insert the copy right below the selection.
+Choosing Duplicate will make a copy of the selected block and insert the copy right below the selection.

--- a/essential-documentation/get-started/how-to-get-help.md
+++ b/essential-documentation/get-started/how-to-get-help.md
@@ -12,7 +12,7 @@ What you are looking at - the AppFlowy Essential Documentation - is likely one o
 
 ## Ask The Community
 
-We encourage to join our community to make AppFlowy a world-class open-source project!
+We encourage you to join our community to make AppFlowy a world-class open-source project!
 
 * Get quick help on [Discord](https://discord.gg/9Q2xaN37tV) along with 1000+ hackers and developers
 * Open issues, PRs, feature requests and vote on them on [Github](https://github.com/AppFlowy-IO/appflowy)

--- a/essential-documentation/markdown.md
+++ b/essential-documentation/markdown.md
@@ -42,8 +42,8 @@ You can press `Tab` or `Shift + Tab` to indent or unindent a list item.
 To create a checkbox item, start with a hyphen `-` and followed by `[]` or `[x]`, `and` press `space`
 
 ```md
--[x] This is a completed task.
--[] This is an incomplete task.
+- [x] This is a completed task.
+- [ ] This is an incomplete task.
 ```
 
 You can press `Tab` or `Shift + Tab` to indent or unindent a checkbox item.

--- a/essential-documentation/markdown.md
+++ b/essential-documentation/markdown.md
@@ -39,7 +39,7 @@ You can press `Tab` or `Shift + Tab` to indent or unindent a list item.
 
 ### Checkbox
 
-To create a checkbox item, start with a hyphen `-` and followed by `[]` or `[x]`, `and` press `space`
+To create a checkbox item, start with a hyphen `-` and followed by `[ ]` or `[x]`, `and` press `space`
 
 ```md
 - [x] This is a completed task.

--- a/essential-documentation/shortcuts.md
+++ b/essential-documentation/shortcuts.md
@@ -7,67 +7,67 @@ You may scroll or use `CTRL` (or `⌘`)`+F` to search for what you are looking f
 
 ## Basics
 
-| Description                            | Key#1                    | Key#2   | Key#3 |
-| -------------------------------------- | ------------------------ | ------- | ----- |
-| Go Up                                  | `↑`                      |         |       |
-| Go Left                                | `←`                      |         |       |
-| Go Bottom                              | `↓`                      |         |       |
-| Go Right                               | `→`                      |         |       |
-| Copy                                   | `CTRL` (or `⌘` on MacOS) | `C`     |       |
-| Paste                                  | `CTRL` (or `⌘` on MacOS) | `V`     |       |
-| Cut                                    | `CTRL` (or `⌘` on MacOS) | `X`     |       |
-| Redo                                   | `CTRL`                   | `Y`     |       |
-| OR                                     |                          |         |       |
-| Redo                                   | `CTRL` (or `⌘` on MacOS) | `Shift` | `Z`   |
-| Undo                                   | `CTRL` (or `⌘` on MacOS) | `Z`     |       |
-| Home                                   | `Home`                   |         |       |
-| End                                    | `End`                    |         |       |
-| Backspace Text                         | `← Backspace`            |         |       |
-| Delete Text                            | `Delete`                 |         |       |
-| Enter                                  | `Enter`                  |         |       |
-| Space                                  | `Space`                  |         |       |
-| Select All                             | `CTRL` (or `⌘` on MacOS) | `A`     |       |
-| Page Up                                | `Page Up`                |         |       |
-| Page Down                              | `Page Down`              |         |       |
-| Tab                                    | `⇥ Tab`                  |         |       |
-| Indent in Checkboxes and Bullet Lists  | `⇥ Tab`                  |         |       |
-| Outdent in Checkboxes and Bullet Lists | `Shift`                  | `⇥ Tab` |       |
-| Selection Menu                         | `/`                      |         |       |
-| OR                                     |                          |         |       |
-| Selection Menu                         | `Shift`                  | `/`     |       |
-| Markdown link or image                 | `Shift`                  | `)`     |       |
-| Exit Editing Mode                      | `Esc`                    |         |       |
-| Move cursor top                        | `CTRL` (or `⌘` on MacOS) | `↑`     |       |
-| Move cursor bottom                     | `CTRL` (or `⌘` on MacOS) | `↓`     | -     |
-| Move cursor start                      | `CTRL` (or `⌘` on MacOS) | `←`     |       |
-| Move cursor end                        | `CTRL` (or `⌘` on MacOS) | `→`     |       |
+| Description                            | Key #1                    | Key #2   | Key #3 |
+| -------------------------------------- | ------------------------  | ------- | ------- |
+| Go Up                                  | `↑`                       |         |         |
+| Go Left                                | `←`                       |         |         |
+| Go Bottom                              | `↓`                       |         |         |
+| Go Right                               | `→`                       |         |         |
+| Copy                                   | `CTRL` (or `⌘` on MacOS)  | `C`     |         |
+| Paste                                  | `CTRL` (or `⌘` on MacOS)  | `V`     |         |
+| Cut                                    | `CTRL` (or `⌘` on MacOS)  | `X`     |         |
+| Redo                                   | `CTRL`                    | `Y`     |         |
+| OR                                     |                           |         |         |
+| Redo                                   | `CTRL` (or `⌘` on MacOS)  | `Shift` | `Z`     |
+| Undo                                   | `CTRL` (or `⌘` on MacOS)  | `Z`     |         |
+| Home                                   | `Home`                    |         |         |
+| End                                    | `End`                     |         |         |
+| Backspace Text                         | `← Backspace`             |         |         |
+| Delete Text                            | `Delete`                  |         |         |
+| Enter                                  | `Enter`                   |         |         |
+| Space                                  | `Space`                   |         |         |
+| Select All                             | `CTRL` (or `⌘` on MacOS)  | `A`     |         |
+| Page Up                                | `Page Up`                 |         |         |
+| Page Down                              | `Page Down`               |         |         |
+| Tab                                    | `⇥ Tab`                   |         |         |
+| Indent in Checkboxes and Bullet Lists  | `⇥ Tab`                   |         |         |
+| Outdent in Checkboxes and Bullet Lists | `Shift`                   | `⇥ Tab` |         |
+| Selection Menu                         | `/`                       |         |         |
+| OR                                     |                           |         |         |
+| Selection Menu                         | `Shift`                   | `/`     |         |
+| Markdown link or image                 | `Shift`                   | `)`     |         |
+| Exit Editing Mode                      | `Esc`                     |         |         |
+| Move cursor top                        | `CTRL` (or `⌘` on MacOS)  | `↑`     |         |
+| Move cursor bottom                     | `CTRL` (or `⌘` on MacOS)  | `↓`     | -       |
+| Move cursor start                      | `CTRL` (or `⌘` on MacOS)  | `←`     |         |
+| Move cursor end                        | `CTRL` (or `⌘` on MacOS)  | `→`     |         |
 
 ## Formatting
 
-|                                           |                          |         |       |
-| ----------------------------------------- | ------------------------ | ------- | ----- |
-| Description                               | Key#1                    | Key#2   | Key#3 |
-| Format Bold                               | `CTRL` (or `⌘` on MacOS) | `B`     |       |
-| Format Italic                             | `CTRL` (or `⌘` on MacOS) | `I`     |       |
-| Format Underline                          | `CTRL` (or `⌘` on MacOS) | `U`     |       |
-| Toggle Checkbox                           | `CTRL` (or `⌘` on MacOS) | `Enter` |       |
-| Format Strikethrough                      | `CTRL` (or `⌘` on MacOS) | `Shift` | `S`   |
-| Format Highlight                          | `CTRL` (or `⌘` on MacOS) | `Shift` | `H`   |
-| Format embed code                         | `CTRL` (or `⌘` on MacOS) | `E`     |       |
-| Underscore to italic                      | `Shift`                  | `_`     |       |
-| Double Stars to Bold                      | `Shift`                  | `*`     |       |
-| Backquotes around text to code            | `` `format as code` ``   |         |       |
-| Double tilde around text to strikethrough | `~~strikethrough~~`      |         |       |
-| OR                                        |                          |         |       |
-| Double tilde to strikethrough             | `Shift`                  | `~`     |       |
+|                                           |                           |          |        |
+| ----------------------------------------- | ------------------------- | -------- | ------ |
+| Description                               | Key #1                    | Key #2   | Key #3 |
+| Format Bold                               | `CTRL` (or `⌘` on MacOS)  | `B`      |        |
+| Format Italic                             | `CTRL` (or `⌘` on MacOS)  | `I`      |        |
+| Format Underline                          | `CTRL` (or `⌘` on MacOS)  | `U`      |        |
+| Toggle Checkbox                           | `CTRL` (or `⌘` on MacOS)  | `Enter`  |        |
+| Format Strikethrough                      | `CTRL` (or `⌘` on MacOS)  | `Shift`  | `S`    |
+| Format Highlight                          | `CTRL` (or `⌘` on MacOS)  | `Shift`  | `H`    |
+| Format embed code                         | `CTRL` (or `⌘` on MacOS)  | `E`      |        |
+| Underscore to italic                      | `Shift`                   | `_`      |        |
+| Double Stars to Bold                      | `Shift`                   | `*`      |        |
+| Backquotes around text to code            | `` `format as code` ``    |          |        |
+| Double tilde around text to strikethrough | `~~strikethrough~~`       |          |        |
+| OR                                        |                           |          |        |
+| Double tilde to strikethrough             | `Shift`                   | `~`      |        |
 
 ## Selection
 
-<table><thead><tr><th width="201">Description</th><th width="194">Key#1</th><th width="203">Key#2</th><th>Key #3</th></tr></thead><tbody><tr><td>Cursor up select</td><td><code>Shift</code></td><td><code>↑</code></td><td></td></tr><tr><td>Cursor down select</td><td><code>Shift</code></td><td><code>↓</code></td><td></td></tr><tr><td>Cursor left select</td><td><code>Shift</code></td><td><code>←</code></td><td></td></tr><tr><td>Cursor right select</td><td><code>Shift</code></td><td><code>→</code></td><td></td></tr><tr><td>Cursor left word select</td><td><code>Shift</code></td><td><code>ALT</code> (or <code>⌥</code> on MacOS)</td><td><code>←</code></td></tr><tr><td>Cursor right word select</td><td><code>Shift</code></td><td><code>ALT</code> (or <code>⌥</code> on MacOS)</td><td><code>→</code></td></tr><tr><td>Cursor left word delete</td><td><code>CTRL</code> (or <code>⌥</code> on MacOS)</td><td><code>← Backspace</code></td><td></td></tr><tr><td>Cursor right word delete</td><td><code>CTRL</code> (or <code>⌥</code> on MacOS)</td><td><code>Delete</code></td><td></td></tr><tr><td>Cursor sentence delete</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>ALT</code> (or <code>n/a</code> on MacOS)</td><td><code>← Backspace</code></td></tr><tr><td>Cursor jump from word to word</td><td><code>ALT</code> (or <code>⌥</code> on MacOS)</td><td><code>←</code> or <code>→</code></td><td></td></tr><tr><td>Cursor top select</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>Shift</code></td><td><code>↑</code></td></tr><tr><td>Cursor bottom select</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>Shift</code></td><td><code>↓</code></td></tr><tr><td>Cursor begin select</td><td> <code>⌘</code> </td><td><code>Shift</code></td><td><code>←</code></td></tr><tr><td>OR</td><td></td><td></td><td></td></tr><tr><td>Cursor begin select</td><td><code>Shift</code></td><td><code>Home</code></td><td></td></tr><tr><td>Cursor end select</td><td><code>⌘</code> </td><td><code>Shift</code></td><td><code>→</code></td></tr><tr><td>OR</td><td></td><td></td><td></td></tr><tr><td>Cursor end select</td><td><code>Shift</code></td><td><code>End</code></td><td></td></tr></tbody></table>
+<table><thead><tr><th width="201">Description</th><th width="194">Key #1</th><th width="203">Key #2</th><th>Key #3</th></tr></thead><tbody><tr><td>Cursor up select</td><td><code>Shift</code></td><td><code>↑</code></td><td></td></tr><tr><td>Cursor down select</td><td><code>Shift</code></td><td><code>↓</code></td><td></td></tr><tr><td>Cursor left select</td><td><code>Shift</code></td><td><code>←</code></td><td></td></tr><tr><td>Cursor right select</td><td><code>Shift</code></td><td><code>→</code></td><td></td></tr><tr><td>Cursor left word select</td><td><code>Shift</code></td><td><code>ALT</code> (or <code>⌥</code> on MacOS)</td><td><code>←</code></td></tr><tr><td>Cursor right word select</td><td><code>Shift</code></td><td><code>ALT</code> (or <code>⌥</code> on MacOS)</td><td><code>→</code></td></tr><tr><td>Cursor left word delete</td><td><code>CTRL</code> (or <code>⌥</code> on MacOS)</td><td><code>← Backspace</code></td><td></td></tr><tr><td>Cursor right word delete</td><td><code>CTRL</code> (or <code>⌥</code> on MacOS)</td><td><code>Delete</code></td><td></td></tr><tr><td>Cursor sentence delete</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>ALT</code> (or <code>n/a</code> on MacOS)</td><td><code>← Backspace</code></td></tr><tr><td>Cursor jump from word to word</td><td><code>ALT</code> (or <code>⌥</code> on MacOS)</td><td><code>←</code> or <code>→</code></td><td></td></tr><tr><td>Cursor top select</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>Shift</code></td><td><code>↑</code></td></tr><tr><td>Cursor bottom select</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>Shift</code></td><td><code>↓</code></td></tr><tr><td>Cursor begin select</td><td> <code>⌘</code> </td><td><code>Shift</code></td><td><code>←</code></td></tr><tr><td>OR</td><td></td><td></td><td></td></tr><tr><td>Cursor begin select</td><td><code>Shift</code></td><td><code>Home</code></td><td></td></tr><tr><td>Cursor end select</td><td><code>⌘</code> </td><td><code>Shift</code></td><td><code>→</code></td></tr><tr><td>OR</td><td></td><td></td><td></td></tr><tr><td>Cursor end select</td><td><code>Shift</code></td><td><code>End</code></td><td></td></tr></tbody></table>
 
 ## App
 
-<table><thead><tr><th width="197">Description</th><th width="200">Key#1</th><th width="202">Key#2</th><th>Key #3</th></tr></thead><tbody><tr><td>Open the Workspace Search</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>P</code></td><td></td></tr><tr><td>Show or Hide Sidebar</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>\</code></td><td></td></tr><tr><td>Toggle Theme Mode (Light/Dark)</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>Shift</code></td><td><code>L</code></td></tr><tr><td>Open Find and Replace dialog (in edit mode doc)</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>F</code></td><td></td></tr></tbody></table>
+<table><thead><tr><th width="197">Description</th><th width="200">Key #1</th><th width="202">Key #2</th><th>Key #3</th></tr></thead><tbody><tr><td>Open the Workspace Search</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>P</code></td><td></td></tr><tr><td>Show or Hide Sidebar</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>\</code></td><td></td></tr><tr><td>Toggle Theme Mode (Light/Dark)</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>Shift</code></td><td><code>L</code></td></tr><tr><td>Open Find and Replace dialog (in edit mode doc)</td><td><code>CTRL</code> (or <code>⌘</code> on MacOS)</td><td><code>F</code></td><td></td></tr></tbody></table>
 
 
 
@@ -75,19 +75,19 @@ You may scroll or use `CTRL` (or `⌘`)`+F` to search for what you are looking f
 
 Kanban shortcuts can't be personalized through Settings. [Request](https://github.com/AppFlowy-IO/AppFlowy/issues/new/choose) it on GitHub.
 
-| Description                                                         | Key#1         | Key#2      |
-| ------------------------------------------------------------------- | ------------- | ---------- |
-| Navigate cards (Up)                                                 | `↑`           |            |
-| Navigate cards (Down)                                               | `↓`           |            |
-| Expand card selection from one to more                              | `Shift`       | `↑` or `↓` |
-| Deselecting cards                                                   | `Esc`         |            |
-| Delete selected cards                                               | `← Backspace` |            |
-| Open as a page                                                      | `Enter`       |            |
-| Edit the title of the selected card                                 | `E`           |            |
-| Add a new card when one card is selected                            | `N`           |            |
-| Create a new card below the current one when a card is being edited | `Shift`       | `Enter`    |
-| Move the card to the list to the left                               | `,`           |            |
-| Move the card to the list to the right                              | `.`           |            |
+| Description                                                         | Key #1         | Key #2      |
+| ------------------------------------------------------------------- | -------------- | ----------- |
+| Navigate cards (Up)                                                 | `↑`            |             |
+| Navigate cards (Down)                                               | `↓`            |             |
+| Expand card selection from one to more                              | `Shift`        | `↑` or `↓`  |
+| Deselecting cards                                                   | `Esc`          |             |
+| Delete selected cards                                               | `← Backspace`  |             |
+| Open as a page                                                      | `Enter`        |             |
+| Edit the title of the selected card                                 | `E`            |             |
+| Add a new card when one card is selected                            | `N`            |             |
+| Create a new card below the current one when a card is being edited | `Shift`        | `Enter`     |
+| Move the card to the list to the left                               | `,`            |             |
+| Move the card to the list to the right                              | `.`            |             |
 
 ## 🔧 Customizing Shortcuts
 


### PR DESCRIPTION
Corrected the checkbox markdown example [here](https://github.com/AppFlowy-IO/AppFlowy-Docs/blob/b058a9f9a63da5b2afa4b78f2bbb7c9401c5b9f4/essential-documentation/markdown.md?plain=1#L40).

`[]` should have been `[ ]`

And improved wording.